### PR TITLE
Add PEP 723 notebook viewer extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,12 @@
     "dependencies": {
         "@jupyterlab/application": "^4.0.0",
         "@jupyterlab/coreutils": "^6.0.0",
+        "@jupyterlab/docmanager": "^4.4.4",
+        "@jupyterlab/docregistry": "^4.4.4",
+        "@jupyterlab/notebook": "^4.4.4",
         "@jupyterlab/services": "^7.0.0",
-        "@jupyterlab/settingregistry": "^4.0.0"
+        "@jupyterlab/settingregistry": "^4.0.0",
+        "@lumino/widgets": "^2.7.1"
     },
     "devDependencies": {
         "@jupyterlab/builder": "^4.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin
@@ -5,7 +6,133 @@ import {
 
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
+import { IDocumentManager } from '@jupyterlab/docmanager';
+
+import {
+  DocumentRegistry,
+  IDocumentWidget,
+  DocumentWidget,
+  ABCWidgetFactory
+} from '@jupyterlab/docregistry';
+
+import { INotebookModel } from '@jupyterlab/notebook';
+
+import { Widget } from '@lumino/widgets';
+
 import { requestAPI } from './handler';
+
+/**
+ * Custom notebook viewer widget that displays PEP 723 metadata
+ */
+class Pep723NotebookWidget extends Widget {
+  private _context: DocumentRegistry.IContext<INotebookModel>;
+
+  constructor(context: DocumentRegistry.IContext<INotebookModel>) {
+    super();
+    this._context = context;
+    this.addClass('pep723-notebook-widget');
+    this.title.label = 'PEP 723 Viewer';
+    this.title.closable = true;
+    this.title.iconClass = 'jp-NotebookIcon';
+
+    this._createContent();
+    this._context.model.contentChanged.connect(this._onContentChanged, this);
+  }
+
+  private _createContent(): void {
+    const container = document.createElement('div');
+    container.className = 'pep723-container';
+
+    const header = document.createElement('h2');
+    header.textContent = 'PEP 723 Inline Script Metadata Viewer';
+    container.appendChild(header);
+
+    const notebookInfo = document.createElement('div');
+    notebookInfo.className = 'notebook-info';
+    notebookInfo.innerHTML = `
+      <p><strong>Notebook:</strong> ${this._context.path}</p>
+      <p><strong>Cells:</strong> ${this._context.model.cells.length}</p>
+    `;
+    container.appendChild(notebookInfo);
+
+    const metadataSection = document.createElement('div');
+    metadataSection.className = 'metadata-section';
+    this._updateMetadataContent(metadataSection);
+    container.appendChild(metadataSection);
+
+    this.node.appendChild(container);
+  }
+
+  private _updateMetadataContent(container: HTMLElement): void {
+    container.innerHTML = '<h3>PEP 723 Script Metadata</h3>';
+
+    const cells = this._context.model.cells;
+    let foundMetadata = false;
+
+    for (let i = 0; i < cells.length; i++) {
+      const cell = cells.get(i);
+      if (cell.type === 'code') {
+        const source = cell.sharedModel.getSource();
+
+        // Look for PEP 723 script metadata (# /// ... # ///)
+        const pep723Regex = /^#\s*\/\/\/\s*(.*)$/gm;
+        const matches: RegExpMatchArray[] = [];
+        let match: RegExpExecArray | null;
+        while ((match = pep723Regex.exec(source)) !== null) {
+          matches.push(match);
+        }
+
+        if (matches.length > 0) {
+          foundMetadata = true;
+          const cellDiv = document.createElement('div');
+          cellDiv.className = 'pep723-cell';
+          cellDiv.innerHTML = `
+            <h4>Cell ${i + 1}</h4>
+            <pre class="pep723-metadata">${matches.map((m: RegExpMatchArray) => m[1]).join('\n')}</pre>
+          `;
+          container.appendChild(cellDiv);
+        }
+      }
+    }
+
+    if (!foundMetadata) {
+      const noMetadata = document.createElement('p');
+      noMetadata.textContent =
+        'No PEP 723 script metadata found in this notebook.';
+      noMetadata.className = 'no-metadata';
+      container.appendChild(noMetadata);
+    }
+  }
+
+  private _onContentChanged(): void {
+    const metadataSection = this.node.querySelector('.metadata-section');
+    if (metadataSection) {
+      this._updateMetadataContent(metadataSection as HTMLElement);
+    }
+  }
+
+  dispose(): void {
+    this._context.model.contentChanged.disconnect(this._onContentChanged, this);
+    super.dispose();
+  }
+}
+
+/**
+ * Widget factory for PEP 723 notebook viewer
+ */
+class Pep723NotebookWidgetFactory extends ABCWidgetFactory<
+  IDocumentWidget<Pep723NotebookWidget, INotebookModel>,
+  INotebookModel
+> {
+  protected createNewWidget(
+    context: DocumentRegistry.IContext<INotebookModel>
+  ): IDocumentWidget<Pep723NotebookWidget, INotebookModel> {
+    const content = new Pep723NotebookWidget(context);
+    const widget = new DocumentWidget({ content, context });
+    widget.title.label = `PEP 723: ${context.localPath}`;
+    return widget;
+  }
+}
 
 /**
  * Initialization data for the pep723widget extension.
@@ -15,12 +142,27 @@ const plugin: JupyterFrontEndPlugin<void> = {
   description:
     'A JupyterLab extension to edit pep723 inline script metadata in notebooks.',
   autoStart: true,
+  requires: [IDocumentManager],
   optional: [ISettingRegistry],
   activate: (
     app: JupyterFrontEnd,
+    docManager: IDocumentManager,
     settingRegistry: ISettingRegistry | null
   ) => {
     console.log('JupyterLab extension pep723widget is activated!');
+
+    // Create and register the widget factory
+    const factory = new Pep723NotebookWidgetFactory({
+      name: 'pep723-notebook-viewer',
+      label: 'PEP 723 Viewer',
+      fileTypes: ['notebook'],
+      defaultFor: [],
+      canStartKernel: false,
+      shutdownOnClose: false,
+      modelName: 'notebook'
+    });
+
+    docManager.registry.addWidgetFactory(factory);
 
     if (settingRegistry) {
       settingRegistry

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-
 import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "incremental": true,
     "jsx": "react",
-    "lib": ["DOM", "ES2018", "ES2020.Intl"],
+    "lib": ["DOM", "ES2020", "ES2020.Intl"],
     "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7706,9 +7706,13 @@ __metadata:
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/builder": ^4.0.0
     "@jupyterlab/coreutils": ^6.0.0
+    "@jupyterlab/docmanager": ^4.4.4
+    "@jupyterlab/docregistry": ^4.4.4
+    "@jupyterlab/notebook": ^4.4.4
     "@jupyterlab/services": ^7.0.0
     "@jupyterlab/settingregistry": ^4.0.0
     "@jupyterlab/testutils": ^4.0.0
+    "@lumino/widgets": ^2.7.1
     "@types/jest": ^29.2.0
     "@types/json-schema": ^7.0.11
     "@types/react": ^18.0.26


### PR DESCRIPTION
## Summary
- Implement custom notebook viewer for PEP 723 inline script metadata
- Add DocumentWidget extension that appears in "Open With..." context menu for .ipynb files  
- Create widget that scans and displays PEP 723 metadata with real-time updates

## Implementation Details
- **Pep723NotebookWidget**: Custom widget extending Widget from @lumino/widgets
- **Pep723NotebookWidgetFactory**: Factory extending ABCWidgetFactory for creating document widgets
- **Plugin registration**: Uses IDocumentManager dependency injection to register with document registry
- **Real-time updates**: Automatically refreshes when notebook content changes
- **PEP 723 detection**: Scans code cells for `# /// ... # ///` metadata patterns

## Dependencies Added
- @jupyterlab/docmanager ^4.4.4
- @jupyterlab/docregistry ^4.4.4  
- @jupyterlab/notebook ^4.4.4
- @lumino/widgets ^2.7.1

## Test plan
- [ ] Build and install extension in development mode
- [ ] Open a notebook with PEP 723 metadata via "Open With..." → "PEP 723 Viewer"
- [ ] Verify metadata is displayed correctly
- [ ] Test real-time updates when modifying notebook content
- [ ] Verify extension loads without errors in JupyterLab

🤖 Generated with [Claude Code](https://claude.ai/code)