### PR TITLE
Add PEP 723 dependency management feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ cd ui-tests && jlpm test
 ### Linting and Code Quality
 
 ```bash
-# Run all linting
+# Run all linting (REQUIRED before committing)
 jlpm lint
 
 # Individual linting tools
@@ -64,6 +64,8 @@ jlpm stylelint      # CSS linting
 # Check only (no fixes)
 jlpm lint:check
 ```
+
+**IMPORTANT**: Always run `jlpm lint` before committing code. The CI uses `jlpm lint:check` which will fail if code is not properly formatted. Running `jlpm lint` auto-fixes formatting issues that `jlpm lint:check` only detects.
 
 ### Cleanup
 

--- a/pep723widget/handlers.py
+++ b/pep723widget/handlers.py
@@ -1,8 +1,13 @@
 import json
+import os
+import tempfile
+import subprocess
+import shutil
 
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 import tornado
+import uv
 
 class RouteHandler(APIHandler):
     # The following decorator should be present on all verb methods (head, get, post,
@@ -15,10 +20,109 @@ class RouteHandler(APIHandler):
         }))
 
 
+class AddDependencyHandler(APIHandler):
+    @tornado.web.authenticated
+    def post(self):
+        """Add a dependency to PEP 723 script metadata using uv"""
+        try:
+            # Parse request body
+            data = json.loads(self.request.body)
+            script_metadata = data.get("script_metadata", "")
+            dependency = data.get("dependency", "")
+            
+            if not script_metadata or not dependency:
+                self.set_status(400)
+                self.finish(json.dumps({
+                    "error": "Both script_metadata and dependency are required"
+                }))
+                return
+            
+            # Validate dependency name (basic security check)
+            if not self._is_valid_dependency_name(dependency):
+                self.set_status(400)
+                self.finish(json.dumps({
+                    "error": "Invalid dependency name"
+                }))
+                return
+            
+            # Get uv executable
+            try:
+                uv_bin = uv.find_uv_bin()
+            except Exception as e:
+                self.set_status(500)
+                self.finish(json.dumps({
+                    "error": f"uv not available: {str(e)}"
+                }))
+                return
+            
+            # Create temporary directory
+            temp_dir = tempfile.mkdtemp()
+            temp_py_file = os.path.join(temp_dir, "script.py")
+            
+            try:
+                # Write script metadata to temporary file
+                with open(temp_py_file, 'w') as f:
+                    f.write(script_metadata)
+                
+                # Run uv add command
+                result = subprocess.run(
+                    [uv_bin, "add", "--script", temp_py_file, dependency],
+                    capture_output=True,
+                    text=True,
+                    cwd=temp_dir
+                )
+                
+                if result.returncode != 0:
+                    self.set_status(500)
+                    self.finish(json.dumps({
+                        "error": f"uv add failed: {result.stderr}"
+                    }))
+                    return
+                
+                # Read updated file
+                with open(temp_py_file, 'r') as f:
+                    updated_metadata = f.read()
+                
+                self.finish(json.dumps({
+                    "updated_metadata": updated_metadata
+                }))
+                
+            finally:
+                # Clean up temporary directory
+                shutil.rmtree(temp_dir, ignore_errors=True)
+                
+        except json.JSONDecodeError:
+            self.set_status(400)
+            self.finish(json.dumps({
+                "error": "Invalid JSON in request body"
+            }))
+        except Exception as e:
+            self.set_status(500)
+            self.finish(json.dumps({
+                "error": f"Internal server error: {str(e)}"
+            }))
+    
+    def _is_valid_dependency_name(self, dependency):
+        """Basic validation for dependency names to prevent command injection"""
+        # Allow alphanumeric, hyphens, underscores, dots, brackets, and spaces for version specs
+        import re
+        pattern = r'^[a-zA-Z0-9\-_\.\[\]\s<>=!,]+$'
+        return bool(re.match(pattern, dependency)) and len(dependency) <= 200
+
+
 def setup_handlers(web_app):
     host_pattern = ".*$"
 
     base_url = web_app.settings["base_url"]
+    
+    # Existing handler
     route_pattern = url_path_join(base_url, "pep723widget", "get-example")
-    handlers = [(route_pattern, RouteHandler)]
+    
+    # New add-dependency handler
+    add_dependency_pattern = url_path_join(base_url, "pep723widget", "add-dependency")
+    
+    handlers = [
+        (route_pattern, RouteHandler),
+        (add_dependency_pattern, AddDependencyHandler)
+    ]
     web_app.add_handlers(host_pattern, handlers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "jupyter_server>=2.4.0,<3"
+    "jupyter_server>=2.4.0,<3",
+    "uv"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,71 +43,241 @@ class Pep723NotebookWidget extends Widget {
     container.className = 'pep723-container';
 
     const header = document.createElement('h2');
-    header.textContent = 'PEP 723 Inline Script Metadata Viewer';
+    header.textContent = 'PEP 723 Dependency Manager';
     container.appendChild(header);
 
+    // Validate the notebook state
+    const validationResult = this._validateNotebook();
+
+    if (!validationResult.valid) {
+      this._createErrorPage(container, validationResult.error!);
+      this.node.appendChild(container);
+      return;
+    }
+
+    // Show the main interface
+    this._createMainInterface(container);
+    this.node.appendChild(container);
+  }
+
+  private _createErrorPage(container: HTMLElement, error: string): void {
+    const errorDiv = document.createElement('div');
+    errorDiv.className = 'pep723-error';
+    errorDiv.innerHTML = `
+      <div class="error-icon">⚠️</div>
+      <h3>Configuration Error</h3>
+      <p>${error}</p>
+      <div class="error-help">
+        <h4>Requirements:</h4>
+        <ul>
+          <li>PEP 723 metadata must be in the first cell of the notebook</li>
+          <li>The cell must contain only PEP 723 metadata and whitespace</li>
+          <li>No other code or comments should be present in the cell</li>
+        </ul>
+      </div>
+    `;
+    container.appendChild(errorDiv);
+  }
+
+  private _createMainInterface(container: HTMLElement): void {
     const notebookInfo = document.createElement('div');
     notebookInfo.className = 'notebook-info';
     notebookInfo.innerHTML = `
       <p><strong>Notebook:</strong> ${this._context.path}</p>
-      <p><strong>Cells:</strong> ${this._context.model.cells.length}</p>
+      <p><strong>Status:</strong> Ready for dependency management</p>
     `;
     container.appendChild(notebookInfo);
 
+    // Current metadata display
     const metadataSection = document.createElement('div');
     metadataSection.className = 'metadata-section';
     this._updateMetadataContent(metadataSection);
     container.appendChild(metadataSection);
 
-    this.node.appendChild(container);
+    // Dependency management form
+    const formSection = document.createElement('div');
+    formSection.className = 'dependency-form';
+    this._createDependencyForm(formSection);
+    container.appendChild(formSection);
   }
 
-  private _updateMetadataContent(container: HTMLElement): void {
-    container.innerHTML = '<h3>PEP 723 Script Metadata</h3>';
+  private _createDependencyForm(container: HTMLElement): void {
+    const formTitle = document.createElement('h3');
+    formTitle.textContent = 'Add New Dependency';
+    container.appendChild(formTitle);
 
+    const form = document.createElement('div');
+    form.className = 'form-group';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.id = 'dependency-input';
+    input.placeholder = 'e.g., requests, pandas>=2.0.0, numpy[dev]';
+    input.className = 'dependency-input';
+
+    const button = document.createElement('button');
+    button.textContent = 'Add Dependency';
+    button.className = 'add-dependency-btn';
+    button.onclick = () => this._addDependency();
+
+    const status = document.createElement('div');
+    status.id = 'status-message';
+    status.className = 'status-message';
+
+    form.appendChild(input);
+    form.appendChild(button);
+    form.appendChild(status);
+    container.appendChild(form);
+  }
+
+  private _validateNotebook(): { valid: boolean; error?: string } {
     const cells = this._context.model.cells;
-    let foundMetadata = false;
 
-    for (let i = 0; i < cells.length; i++) {
+    if (cells.length === 0) {
+      return { valid: false, error: 'Notebook has no cells.' };
+    }
+
+    const firstCell = cells.get(0);
+    if (firstCell.type !== 'code') {
+      return { valid: false, error: 'First cell must be a code cell.' };
+    }
+
+    const source = firstCell.sharedModel.getSource();
+
+    // Use the canonical PEP 723 regex pattern
+    // (?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$
+    const pep723Regex = /^# \/\/\/ [a-zA-Z0-9-]+$\s(^#( .*)?$\s)+^# \/\/\/$/m;
+    
+    if (!pep723Regex.test(source)) {
+      return {
+        valid: false,
+        error: 'First cell must contain valid PEP 723 script metadata.'
+      };
+    }
+
+    // Check if cell contains only PEP 723 metadata and whitespace
+    const lines = source.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed === '') {
+        continue; // Allow empty lines
+      }
+      // Valid PEP 723 lines: # /// type, # content, # ///
+      if (!trimmed.match(/^# \/\/\/ [a-zA-Z0-9-]+$/) && 
+          !trimmed.match(/^#( .*)?$/) && 
+          !trimmed.match(/^# \/\/\/$/)) {
+        return {
+          valid: false,
+          error: 'First cell must contain only PEP 723 metadata and whitespace. Found non-metadata content.'
+        };
+      }
+    }
+
+    // Check that no other cells contain PEP 723 metadata
+    const startMarkerRegex = /^# \/\/\/ [a-zA-Z0-9-]+$/m;
+    for (let i = 1; i < cells.length; i++) {
       const cell = cells.get(i);
       if (cell.type === 'code') {
-        const source = cell.sharedModel.getSource();
-
-        // Look for PEP 723 script metadata (# /// ... # ///)
-        const pep723Regex = /^#\s*\/\/\/\s*(.*)$/gm;
-        const matches: RegExpMatchArray[] = [];
-        let match: RegExpExecArray | null;
-        while ((match = pep723Regex.exec(source)) !== null) {
-          matches.push(match);
-        }
-
-        if (matches.length > 0) {
-          foundMetadata = true;
-          const cellDiv = document.createElement('div');
-          cellDiv.className = 'pep723-cell';
-          cellDiv.innerHTML = `
-            <h4>Cell ${i + 1}</h4>
-            <pre class="pep723-metadata">${matches.map((m: RegExpMatchArray) => m[1]).join('\n')}</pre>
-          `;
-          container.appendChild(cellDiv);
+        const cellSource = cell.sharedModel.getSource();
+        if (startMarkerRegex.test(cellSource)) {
+          return {
+            valid: false,
+            error: `PEP 723 metadata found in cell ${i + 1}. Metadata must only be in the first cell.`
+          };
         }
       }
     }
 
-    if (!foundMetadata) {
-      const noMetadata = document.createElement('p');
-      noMetadata.textContent =
-        'No PEP 723 script metadata found in this notebook.';
-      noMetadata.className = 'no-metadata';
-      container.appendChild(noMetadata);
+    return { valid: true };
+  }
+
+  private _updateMetadataContent(container: HTMLElement): void {
+    container.innerHTML = '<h3>Current Script Metadata</h3>';
+
+    const firstCell = this._context.model.cells.get(0);
+    const source = firstCell.sharedModel.getSource();
+
+    const metadataDiv = document.createElement('div');
+    metadataDiv.className = 'current-metadata';
+    metadataDiv.innerHTML = `<pre>${source}</pre>`;
+    container.appendChild(metadataDiv);
+  }
+
+  private async _addDependency(): Promise<void> {
+    const input = this.node.querySelector(
+      '#dependency-input'
+    ) as HTMLInputElement;
+    const button = this.node.querySelector(
+      '.add-dependency-btn'
+    ) as HTMLButtonElement;
+    const status = this.node.querySelector('#status-message') as HTMLElement;
+
+    const dependency = input.value.trim();
+    if (!dependency) {
+      this._showStatus(status, 'Please enter a dependency name.', 'error');
+      return;
+    }
+
+    // Disable form during request
+    input.disabled = true;
+    button.disabled = true;
+    this._showStatus(status, 'Adding dependency...', 'loading');
+
+    try {
+      // Get current script metadata from first cell
+      const firstCell = this._context.model.cells.get(0);
+      const scriptMetadata = firstCell.sharedModel.getSource();
+
+      // Call backend API
+      const response = await requestAPI<any>('add-dependency', {
+        method: 'POST',
+        body: JSON.stringify({
+          script_metadata: scriptMetadata,
+          dependency: dependency
+        })
+      });
+
+      // Update cell content with new metadata
+      firstCell.sharedModel.setSource(response.updated_metadata);
+
+      // Update UI
+      this._updateMetadataContent(
+        this.node.querySelector('.metadata-section')!
+      );
+      input.value = '';
+      this._showStatus(status, `Successfully added "${dependency}"`, 'success');
+    } catch (error) {
+      console.error('Error adding dependency:', error);
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to add dependency';
+      this._showStatus(status, `Error: ${errorMessage}`, 'error');
+    } finally {
+      // Re-enable form
+      input.disabled = false;
+      button.disabled = false;
+    }
+  }
+
+  private _showStatus(
+    element: HTMLElement,
+    message: string,
+    type: 'success' | 'error' | 'loading'
+  ): void {
+    element.textContent = message;
+    element.className = `status-message ${type}`;
+
+    if (type !== 'loading') {
+      setTimeout(() => {
+        element.textContent = '';
+        element.className = 'status-message';
+      }, 3000);
     }
   }
 
   private _onContentChanged(): void {
-    const metadataSection = this.node.querySelector('.metadata-section');
-    if (metadataSection) {
-      this._updateMetadataContent(metadataSection as HTMLElement);
-    }
+    // Re-create the entire interface to handle validation changes
+    this.node.innerHTML = '';
+    this._createContent();
   }
 
   dispose(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ class Pep723NotebookWidget extends Widget {
     // Use the canonical PEP 723 regex pattern
     // (?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$
     const pep723Regex = /^# \/\/\/ [a-zA-Z0-9-]+$\s(^#( .*)?$\s)+^# \/\/\/$/m;
-    
+
     if (!pep723Regex.test(source)) {
       return {
         valid: false,
@@ -163,12 +163,15 @@ class Pep723NotebookWidget extends Widget {
         continue; // Allow empty lines
       }
       // Valid PEP 723 lines: # /// type, # content, # ///
-      if (!trimmed.match(/^# \/\/\/ [a-zA-Z0-9-]+$/) && 
-          !trimmed.match(/^#( .*)?$/) && 
-          !trimmed.match(/^# \/\/\/$/)) {
+      if (
+        !trimmed.match(/^# \/\/\/ [a-zA-Z0-9-]+$/) &&
+        !trimmed.match(/^#( .*)?$/) &&
+        !trimmed.match(/^# \/\/\/$/)
+      ) {
         return {
           valid: false,
-          error: 'First cell must contain only PEP 723 metadata and whitespace. Found non-metadata content.'
+          error:
+            'First cell must contain only PEP 723 metadata and whitespace. Found non-metadata content.'
         };
       }
     }

--- a/style/base.css
+++ b/style/base.css
@@ -1,5 +1,124 @@
 /*
-    See the JupyterLab Developer Guide for useful CSS Patterns:
-
-    https://jupyterlab.readthedocs.io/en/stable/developer/css.html
+PEP 723 Widget Styles
 */
+
+.pep723-container {
+  padding: 16px;
+  font-family: var(--jp-ui-font-family);
+}
+
+.pep723-error {
+  background: var(--jp-error-color3);
+  border: 1px solid var(--jp-error-color1);
+  border-radius: 4px;
+  padding: 16px;
+  margin: 16px 0;
+}
+
+.pep723-error .error-icon {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.pep723-error h3 {
+  color: var(--jp-error-color1);
+  margin: 0 0 8px;
+}
+
+.pep723-error .error-help {
+  margin-top: 16px;
+  font-size: 0.9em;
+}
+
+.notebook-info {
+  background: var(--jp-layout-color2);
+  padding: 12px;
+  border-radius: 4px;
+  margin: 16px 0;
+}
+
+.metadata-section {
+  margin: 16px 0;
+}
+
+.current-metadata pre {
+  background: var(--jp-layout-color1);
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 4px;
+  padding: 12px;
+  overflow-x: auto;
+  font-family: var(--jp-code-font-family);
+}
+
+.dependency-form {
+  background: var(--jp-layout-color2);
+  padding: 16px;
+  border-radius: 4px;
+  margin: 16px 0;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dependency-input {
+  padding: 8px 12px;
+  border: 1px solid var(--jp-border-color1);
+  border-radius: 4px;
+  font-size: 14px;
+  background: var(--jp-input-background);
+  color: var(--jp-ui-font-color1);
+}
+
+.dependency-input:focus {
+  outline: none;
+  border-color: var(--jp-brand-color1);
+  box-shadow: 0 0 0 2px var(--jp-brand-color3);
+}
+
+.add-dependency-btn {
+  padding: 8px 16px;
+  background: var(--jp-brand-color1);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s;
+}
+
+.add-dependency-btn:disabled {
+  background: var(--jp-layout-color3);
+  cursor: not-allowed;
+}
+
+.add-dependency-btn:hover:not(:disabled) {
+  background: var(--jp-brand-color0);
+}
+
+.status-message {
+  padding: 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  min-height: 20px;
+}
+
+.status-message.success {
+  background: var(--jp-success-color3);
+  color: var(--jp-success-color1);
+  border: 1px solid var(--jp-success-color2);
+}
+
+.status-message.error {
+  background: var(--jp-error-color3);
+  color: var(--jp-error-color1);
+  border: 1px solid var(--jp-error-color2);
+}
+
+.status-message.loading {
+  background: var(--jp-info-color3);
+  color: var(--jp-info-color1);
+  border: 1px solid var(--jp-info-color2);
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive dependency management functionality to the PEP 723 widget extension, allowing users to add Python dependencies to notebook script metadata using the `uv` package manager.

### Key Features

- **Backend API endpoint** (`/pep723widget/add-dependency`) that uses `uv add --script` to update PEP 723 metadata
- **Frontend validation** ensuring PEP 723 metadata is correctly formatted and positioned in first cell only
- **Interactive UI** with dependency input form, real-time status feedback, and error handling
- **Security measures** including input validation and secure temporary file handling

### Technical Implementation

- Added `uv` as Python dependency and used `uv.find_uv_bin()` for reliable executable location
- Implemented canonical PEP 723 regex validation based on specification
- Created comprehensive CSS styling with JupyterLab theme integration
- Added proper error states, loading indicators, and success feedback

### Usage

1. Open a notebook with PEP 723 script metadata in the first cell
2. Use "Open With → PEP 723 Viewer" 
3. Enter dependency name (e.g., `requests`, `pandas>=2.0.0`) and click "Add Dependency"
4. The metadata is automatically updated using `uv add --script`

🤖 Generated with [Claude Code](https://claude.ai/code)