### PR TITLE
Add notebook initialization feature with PEP 723 metadata

### DIFF
--- a/examples/Test2.ipynb
+++ b/examples/Test2.ipynb
@@ -1,0 +1,34 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bcd103f-e1d9-4482-91bd-dd3cf66fd1ad",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  },
+  "uv.lock": "version = 1\nrevision = 2\nrequires-python = \">=3.13\"\n"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/junit.xml
+++ b/junit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests" tests="1" failures="0" errors="0" time="2.166">
+  <testsuite name="pep723widget" errors="0" failures="0" skipped="0" timestamp="2025-08-19T02:01:42" time="1.33" tests="1">
+    <testcase classname="pep723widget should be tested" name="pep723widget should be tested" time="0.001">
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/pep723widget/handlers.py
+++ b/pep723widget/handlers.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import tempfile
 import subprocess
 import shutil
@@ -109,6 +110,99 @@ class GetTreeHandler(APIHandler):
             self.finish(json.dumps({
                 "error": "Invalid JSON in request body"
             }))
+        except Exception as e:
+            self.set_status(500)
+            self.finish(json.dumps({
+                "error": f"Internal server error: {str(e)}"
+            }))
+
+
+class InitializeHandler(APIHandler):
+    @tornado.web.authenticated
+    def post(self):
+        """Initialize PEP 723 script metadata using uv init and uv lock"""
+        try:
+            # Get uv executable
+            try:
+                uv_bin = uv.find_uv_bin()
+            except Exception as e:
+                self.set_status(500)
+                self.finish(json.dumps({
+                    "error": f"uv not available: {str(e)}"
+                }))
+                return
+            
+            # Create temporary directory
+            temp_dir = tempfile.mkdtemp()
+            temp_py_file = os.path.join(temp_dir, "script.py")
+            temp_lock_file = os.path.join(temp_dir, "script.py.lock")
+            
+            try:
+                # Step 1: Run uv init --script to create basic metadata
+                init_result = subprocess.run(
+                    [uv_bin, "init", "--script", temp_py_file],
+                    capture_output=True,
+                    text=True,
+                    cwd=temp_dir
+                )
+                
+                if init_result.returncode != 0:
+                    self.set_status(500)
+                    self.finish(json.dumps({
+                        "error": f"uv init failed: {init_result.stderr}"
+                    }))
+                    return
+                
+                # Step 2: Run uv lock --script to generate lockfile
+                lock_result = subprocess.run(
+                    [uv_bin, "lock", "--script", temp_py_file],
+                    capture_output=True,
+                    text=True,
+                    cwd=temp_dir
+                )
+                
+                if lock_result.returncode != 0:
+                    self.set_status(500)
+                    self.finish(json.dumps({
+                        "error": f"uv lock failed: {lock_result.stderr}"
+                    }))
+                    return
+                
+                # Step 3: Read generated script and extract PEP 723 metadata block
+                with open(temp_py_file, 'r') as f:
+                    script_content = f.read()
+                
+                # Extract only the PEP 723 metadata block using canonical regex
+                pep723_pattern = r'(?m)^# /// (?P<type>[a-zA-Z0-9-]+)$\s(?P<content>(^#(| .*)$\s)+)^# ///$'
+                match = re.search(pep723_pattern, script_content)
+                
+                if not match:
+                    self.set_status(500)
+                    self.finish(json.dumps({
+                        "error": "Failed to extract PEP 723 metadata from generated script"
+                    }))
+                    return
+                
+                # Reconstruct the metadata block
+                metadata_type = match.group('type')
+                metadata_content = match.group('content')
+                initial_metadata = f"# /// {metadata_type}\n{metadata_content}# ///"
+                
+                lockfile_content = None
+                if os.path.exists(temp_lock_file):
+                    with open(temp_lock_file, 'r') as f:
+                        lockfile_content = f.read()
+                
+                # Step 4: Return results
+                self.finish(json.dumps({
+                    "initial_metadata": initial_metadata,
+                    "lockfile_content": lockfile_content
+                }))
+                
+            finally:
+                # Clean up temporary directory
+                shutil.rmtree(temp_dir, ignore_errors=True)
+                
         except Exception as e:
             self.set_status(500)
             self.finish(json.dumps({
@@ -261,9 +355,13 @@ def setup_handlers(web_app):
     # New get-tree handler
     get_tree_pattern = url_path_join(base_url, "pep723widget", "get-tree")
     
+    # New initialize handler
+    initialize_pattern = url_path_join(base_url, "pep723widget", "initialize")
+    
     handlers = [
         (route_pattern, RouteHandler),
         (add_dependency_pattern, AddDependencyHandler),
-        (get_tree_pattern, GetTreeHandler)
+        (get_tree_pattern, GetTreeHandler),
+        (initialize_pattern, InitializeHandler)
     ]
     web_app.add_handlers(host_pattern, handlers)

--- a/style/base.css
+++ b/style/base.css
@@ -33,6 +33,51 @@ PEP 723 Widget Styles
   font-size: 0.9em;
 }
 
+.pep723-init {
+  background: var(--jp-info-color3);
+  border: 1px solid var(--jp-info-color2);
+  border-radius: 4px;
+  padding: 16px;
+  margin: 16px 0;
+}
+
+.pep723-init .init-icon {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.pep723-init h3 {
+  color: var(--jp-info-color1);
+  margin: 0 0 8px;
+}
+
+.pep723-init .init-help {
+  margin: 16px 0;
+  font-size: 0.9em;
+}
+
+.init-btn {
+  padding: 12px 24px;
+  background: var(--jp-brand-color1);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: 500;
+  transition: background-color 0.2s;
+  margin: 16px 0 8px;
+}
+
+.init-btn:disabled {
+  background: var(--jp-layout-color3);
+  cursor: not-allowed;
+}
+
+.init-btn:hover:not(:disabled) {
+  background: var(--jp-brand-color0);
+}
+
 .notebook-info {
   background: var(--jp-layout-color2);
   padding: 12px;


### PR DESCRIPTION
## Summary

- Add initialization UI for notebooks without PEP 723 metadata
- Implement `/initialize` endpoint using `uv init` and `uv lock`
- Extract only metadata block using canonical PEP 723 regex
- Fix empty dependency tree display (show "No dependencies")
- Create new metadata cell as collapsed (source hidden)
- Support end-to-end notebook initialization workflow

## Features Added

### Frontend
- Enhanced validation to detect notebooks without PEP 723 metadata
- Added user-friendly initialization page with explanatory text
- Implemented "Add metadata cell" button functionality
- Fixed empty dependency tree display issue
- New metadata cells created with source code collapsed by default

### Backend
- New `/initialize` endpoint that uses `uv init --script` and `uv lock --script`
- Extracts only PEP 723 metadata block using canonical regex pattern
- Generates and stores lockfile in notebook metadata
- Proper error handling and temporary file cleanup

## Test Plan

- [x] Build passes (`jlpm build`)
- [x] Linting passes (`jlpm lint`)
- [x] Python tests pass (`pytest -vv -r ap --cov pep723widget`)
- [x] Empty dependency arrays show "No dependencies" instead of "Loading..."
- [x] New metadata cells are created collapsed
- [x] Initialization flow works end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)